### PR TITLE
help: use sensible defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,18 +93,17 @@ This allows more detail to be added to your config which will be exposed when yo
 {
 	aliases 		: ['foo'],  	// alias names for task
 	description 	: '', 			// task description for help
-	help 			: true | false	// visible in help
 }
 ```
 > Example help options
 
-This options can be added to plugin or target keys.
+These options can be added to plugin or target keys. Note description can be set to either a string to override the default or a boolean. If you wish to hide a description in help set the value to false.
 
 ## Options
 
 When first initilizing `gulp-config`, an options object can be passed which can be used to customize where tasks are located.
 
-### tasks 
+### tasks
 
 This is used to set where tasks can be found. Passing a single path is supported, in addition an array of paths can also be specified. All paths support glob style matching.
 
@@ -164,6 +163,8 @@ In lieu of a formal styleguide, take care to maintain the existing coding style.
 
 ## Release History
 
+- **0.2.2**
+    - removed task.help && target.help (task|target).description now toggles help display
 - **0.2.1**
     - task scope fixes
     - this.files support added

--- a/lib/index.js
+++ b/lib/index.js
@@ -66,8 +66,13 @@ initConfig = function (config) {
 
             if (self.help) {
 
-                cfg.help = _.isBoolean(cfg.help) ? cfg.help : false; // should taks be displayed in help
-                cfg.help = !!cfg.help && (cfg.description || util.format('Run all targets for "%s"', name));
+                // a) allow description to be hidden
+                // b) allow description to be overriden
+                // c) fallback to default
+
+                cfg.help = _.isBoolean(cfg.description) && !cfg.description ||
+                           _.isString(cfg.description) ? cfg.description : util.format('Run all targets for "%s"', name);
+
                 args.splice(1, 0, cfg.help);
 
                 // ensure task aliases are added, if
@@ -137,8 +142,13 @@ initConfig = function (config) {
 
                 if (self.help) {
 
-                    tgt.help = _.isBoolean(tgt.help) ? tgt.help : true; // should taks be displayed in help
-                    tgt.help = tgt.help && (cfg.description || tgt.description || util.format('Run the "%s" task using target "%s"', name, target));
+                    // a) allow description to be hidden
+                    // b) allow description to be overriden
+                    // c) fallback to default
+
+                    tgt.help = _.isBoolean(tgt.description) && !tgt.description ||
+                               _.isString(tgt.description) ? tgt.description : util.format('Run the "%s" target for "%s"', target, name);
+
                     args.splice(1, 0, tgt.help);
 
                     // ensure task aliases are added, if

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-config",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Provides Grunt like config support to gulp",
   "main": "./lib/index.js",
   "scripts": {


### PR DESCRIPTION
- remove need for explicitly specifying help for targets and tasks

Impact: medium
